### PR TITLE
Refactored rendering process to use pixi.js (closes #2)

### DIFF
--- a/src/TileMap/TileMapLayer.js
+++ b/src/TileMap/TileMapLayer.js
@@ -87,15 +87,19 @@ Fibula.TileMapLayer.prototype = {
 Fibula.TileMapLayer.prototype.fillTiles = function(data)
 {
     this.tiles = [];
-    this.height = this.width = data.length;
+    this.height = data.length;
+    this.width= data[0].length;
     
-    for(var x = 0; x < this.width; x++) {
+    var pos;
+    
+    for(var x = 0; x < data.length; x++) {
         if (typeof this.tiles[x] === "undefined") {
             this.tiles[x] = [];
         }
         
         for(var y = 0; y < this.height; y++) {
-            this.tiles[x][y] = new Fibula.Tile(x, y, data[y][x]);
+            pos = data[y][x] != null ? data[y][x] : NaN;
+            this.tiles[x][y] = new Fibula.Tile(x, y, pos);
         }
     }
 };

--- a/src/TileMap/TileSet.js
+++ b/src/TileMap/TileSet.js
@@ -51,8 +51,6 @@ Fibula.TileSet.prototype = {
  */
 Fibula.TileSet.prototype.findCoordinates = function(index, tileWidth, tileHeight)
 {
-    console.log(tileWidth);
-    
     var tilesPerColumn = this.width / tileWidth,
         tileX = Math.floor(index / tilesPerColumn),
         tileY = Math.floor(index % tilesPerColumn),


### PR DESCRIPTION
This will fix #2.

It's important to notice that, due to a pixi.js limitation, the textures (tileset images) should have power-of-2 dimensions.
